### PR TITLE
Protect from segmentation fault on Graham's Scan

### DIFF
--- a/src/Graham Scan Convex Hull.cpp
+++ b/src/Graham Scan Convex Hull.cpp
@@ -73,7 +73,7 @@ stack<Point> grahamScan(Point *points, int N)    {
     for (int i = 3; i < N; i++) {
         Point top = hull.top();
         hull.pop();
-        while (ccw(hull.top(), top, points[i]) != -1)   {
+        while (!hull.empty() && ccw(hull.top(), top, points[i]) != -1)   {
             top = hull.top();
             hull.pop();
         }


### PR DESCRIPTION
Noticed that segfault occurs for the below testcase:

```
{1,0},{2,1},{3,2},{4,3},{3,4},{2,3},{1,2},{0,1}
```

Added a check that stack is not empty when doing CCW search.

_Love from Rodina ❤️_